### PR TITLE
feat: Add interactive target branch selection

### DIFF
--- a/source/cli.tsx
+++ b/source/cli.tsx
@@ -9,11 +9,12 @@ const cli = meow(
 	  $ auto-rebase [options]
 
 	Options
-		--target <branch>    Target branch to rebase onto (required)
+		--target <branch>    Target branch to rebase onto (optional, interactive selection if omitted)
 
 	Examples
 	  $ auto-rebase --target main
 	  $ auto-rebase --target develop
+	  $ auto-rebase
 `,
 	{
 		importMeta: import.meta,
@@ -25,10 +26,5 @@ const cli = meow(
 		},
 	},
 );
-
-if (!cli.flags.target) {
-	console.error("Error: Target branch is required. Use --target flag");
-	process.exit(1);
-}
 
 render(<App targetBranch={cli.flags.target} />);

--- a/source/git.ts
+++ b/source/git.ts
@@ -43,6 +43,18 @@ export class GitOperations {
 		return status.current || "HEAD";
 	}
 
+	async getAllBranches(): Promise<string[]> {
+		const branches = await this.git.branch(["-r"]);
+		return branches.all
+			.filter(
+				(branch) =>
+					typeof branch === "string" &&
+					branch.startsWith("origin/") &&
+					!branch.includes("HEAD"),
+			)
+			.map((branch) => (branch as string).replace("origin/", ""));
+	}
+
 	async fetchAll(): Promise<void> {
 		await this.git.fetch(["--all"]);
 	}


### PR DESCRIPTION
Allows users to run the `auto-rebase` command without specifying a target branch upfront.

If the `--target` flag is omitted, the application will now:
- Fetch all remote branches.
- Present a list of available branches for the user to select interactively.

This enhances usability by providing a guided experience for users who may not know the exact target branch name or prefer an interactive workflow.