### PR TITLE
ci: Publish package to npm registry

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -1,4 +1,4 @@
-name: Publish to GitHub Packages
+name: Publish to npm
 
 on:
   release:
@@ -10,7 +10,7 @@ jobs:
     timeout-minutes: 10
     permissions:
       contents: read
-      packages: write
+      id-token: write
 
     steps:
       - name: Checkout code
@@ -23,13 +23,17 @@ jobs:
         with:
           bun-version: latest
 
+      - name: Setup Node.js for npm publish
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 #v5.0.0
+        with:
+          node-version: 20
+          registry-url: 'https://registry.npmjs.org'
+
       - name: Install dependencies with frozen lockfile
         run: bun install --frozen-lockfile
 
       - name: Build project
         run: bun run build
 
-      - name: Publish to GitHub Packages
-        run: npm publish
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Publish to npm
+        run: npm publish --provenance

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,51 @@
-node_modules
-dist
+# Dependencies
+node_modules/
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Build output
+dist/
+build/
+*.tsbuildinfo
+
+# Runtime data
+pids
+*.pid
+*.seed
+*.pid.lock
+
+# Coverage directory used by tools like istanbul
+coverage/
+.nyc_output
+
+# Temporary directories
+.tmp/
+.cache/
+
+# IDEs
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# OS generated files
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db
+
+# Logs
+logs
+*.log
+
+# Environment variables
+.env
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,72 @@
+# Source code (only publish built files)
+src/
+*.ts
+!dist/**/*.d.ts
+
+# Configuration files
+tsconfig.json
+biome.json
+.eslintrc*
+.prettierrc*
+
+# Development dependencies
+package-lock.json
+yarn.lock
+bun.lockb
+
+# Build tools and config
+.github/
+.vscode/
+.idea/
+
+# Tests
+__tests__/
+test/
+tests/
+*.test.js
+*.test.ts
+*.spec.js
+*.spec.ts
+
+# Coverage
+coverage/
+.nyc_output
+
+# Logs
+*.log
+logs/
+
+# Temporary files
+.tmp/
+.cache/
+
+# OS generated files
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db
+
+# IDE files
+*.swp
+*.swo
+*~
+
+# Environment files
+.env*
+
+# Git files
+.gitignore
+.gitattributes
+
+# Documentation build
+docs/
+
+# Examples and demos (if any)
+examples/
+demo/
+
+# Scripts not needed in production
+scripts/

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-//npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}

--- a/package.json
+++ b/package.json
@@ -33,8 +33,7 @@
 		"github"
 	],
 	"publishConfig": {
-		"access": "public",
-		"registry": "https://npm.pkg.github.com"
+		"access": "public"
 	},
 	"dependencies": {
 		"@octokit/rest": "22.0.0",


### PR DESCRIPTION
Migrates the package publishing process from GitHub Packages to the public npm registry.

This change enhances package accessibility by making it available on the primary npm registry. It updates the GitHub Actions workflow to use OIDC for authentication and explicitly targets npmjs.org.

Includes the addition of an `.npmignore` file to optimize package size and contents for npm, and an expanded `.gitignore` for general repository cleanliness.