### PR TITLE
feat: Streamline rebase UX and add project docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,52 @@
+# GEMINI.md
+
+## Project Overview
+
+This project is a command-line interface (CLI) tool named `agrb` (auto git rebase) that provides an interactive and safe way to rebase a Git branch onto another. The tool is built with TypeScript, React (using Ink for the CLI UI), and Node.js.
+
+The core functionality of `agrb` is to simplify the rebase process by offering two different strategies:
+
+1. **Cherry-pick based replay**: This is the default strategy. It identifies the non-merge commits between the current branch and the target branch and applies them one by one to a temporary branch created from the target. This method avoids issues with merge commits in the history.
+2. **Linear history via `git rebase`**: This strategy uses the standard `git rebase` command to create a linear history.
+
+The tool is designed to be interactive, allowing the user to select the target branch from a list of available branches if not specified via command-line arguments.
+
+## Building and Running
+
+The project uses `bun` for package management and running scripts.
+
+**Install Dependencies:**
+
+```bash
+bun install
+```
+
+**Build the project:**
+
+```bash
+bun run build
+```
+
+**Run in development mode (with file watching):**
+
+```bash
+bun run dev
+```
+
+**Lint the code:**
+
+```bash
+bun run lint
+```
+
+**Run tests:**
+
+```bash
+bun run test
+```
+
+## Development Conventions
+
+**Code Style**: The project uses Biome for code formatting and linting. The configuration can be found in the `biome.json` file.
+**Testing**: The project uses Biome for checking the code.
+**Contribution**: Contribution guidelines are available in `CONTRIBUTING.md`.

--- a/README.ja.md
+++ b/README.ja.md
@@ -20,7 +20,6 @@ agrb [options]
 
 - `--target, -t <branch>`: 対象ブランチ。未指定の場合はインタラクティブに選択します
 - `--allow-empty`: cherry-pick時に空コミットを許可します
-- `--skip`: cherry-pick時に空コミットやコンフリクト発生コミットをスキップします
 - `--linear`: `git rebase` による線形履歴モードを使用します（デフォルトはcherry-pickベース）
 - `--continue-on-conflict`: 線形rebase時にコンフリクトが出ても継続（`-X ours`を使用し、自動解決して`--continue`を試行）
 - `--remote-target`: 対象ブランチの選択にリモート追跡ブランチ（`origin/*`）を使用します
@@ -40,14 +39,13 @@ agrb --linear --continue-on-conflict
 # 対象ブランチをリモートブランチから選ぶ
 agrb --remote-target
 
-# 空コミットを許可/スキップ
+# 空コミットを許可
 agrb --allow-empty
-agrb --skip
 ```
 
 ## 動作の概要
 
-デフォルト（cherry-pick）モードでは、ターゲットブランチと現在のブランチの`merge-base`から現在ブランチまでの非マージコミットを順に適用します。空コミットやコンフリクトに対する振る舞いは`--allow-empty`/`--skip`で制御できます。完了後は一時ブランチの内容を現在ブランチへ`reset --hard`で反映します。
+デフォルト（cherry-pick）モードでは、ターゲットブランチと現在のブランチの`merge-base`から現在ブランチまでの非マージコミットを順に適用します。空コミットやコンフリクトは自動でスキップされます。`--allow-empty`で空コミットを意図的に含めることも可能です。完了後は一時ブランチの内容を現在ブランチへ`reset --hard`で反映します。
 
 線形（`--linear`）モードでは、`git rebase origin/<target>`を実行します。`--continue-on-conflict`指定時はコンフリクト検出後に自動解決（`-X ours`）を試み、`git add . && git rebase --continue`を行います。
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # agrb (auto git rebase)
 
+- [日本語](./README.ja.md)
+
 <a href="https://github.com/sponsors/riya-amemiya"><img alt="Sponsor" src="https://img.shields.io/badge/sponsor-30363D?style=for-the-badge&logo=GitHub-Sponsors&logoColor=#white" /></a>
 
 Interactive CLI to safely rebase a branch onto another. Supports two strategies:
@@ -27,7 +29,6 @@ Options:
 
 - `--target, -t <branch>`: Target branch. If omitted, select interactively
 - `--allow-empty`: Allow empty commits during cherry-pick
-- `--skip`: Skip empty/conflicting commits during cherry-pick
 - `--linear`: Use `git rebase` for a linear history (default is cherry-pick)
 - `--continue-on-conflict`: Continue linear rebase when conflicts occur (`-X ours` + `--continue`)
 - `--remote-target`: Select target branch from remote tracking branches (`origin/*`)
@@ -47,14 +48,13 @@ agrb --linear --continue-on-conflict
 # Select target from remote branches
 agrb --remote-target
 
-# Allow/skip empty commits
+# Allow empty commits
 agrb --allow-empty
-agrb --skip
 ```
 
 ## How it works
 
-In the default cherry-pick mode, non-merge commits between `merge-base(<target>, <current>)` and the current branch are applied onto a temporary branch created from `<target>`. On success, the current branch is hard-reset to the temp branch.
+In the default cherry-pick mode, non-merge commits between `merge-base(<target>, <current>)` and the current branch are applied onto a temporary branch created from `<target>`. Empty commits or conflicts are automatically skipped. You can intentionally include empty commits with `--allow-empty`. On success, the current branch is hard-reset to the temp branch.
 
 In linear mode (`--linear`), `git rebase origin/<target>` is executed. With `--continue-on-conflict`, the command tries `-X ours`, stages changes, and runs `git rebase --continue`.
 

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -7,7 +7,6 @@ import { GitOperations } from "./git.js";
 type Props = {
 	targetBranch?: string;
 	allowEmpty?: boolean;
-	skip?: boolean;
 	linear?: boolean;
 	continueOnConflict?: boolean;
 	remoteTarget?: boolean;
@@ -26,7 +25,6 @@ interface RebaseState {
 export default function App({
 	targetBranch,
 	allowEmpty,
-	skip,
 	linear,
 	continueOnConflict,
 	remoteTarget,
@@ -64,7 +62,7 @@ export default function App({
 							message,
 						}));
 					},
-					{ allowEmpty, skip, linear, continueOnConflict },
+					{ allowEmpty, linear, continueOnConflict },
 				);
 
 				setState({
@@ -85,7 +83,7 @@ export default function App({
 				});
 			}
 		},
-		[allowEmpty, skip, linear, continueOnConflict],
+		[allowEmpty, linear, continueOnConflict],
 	);
 
 	useEffect(() => {

--- a/src/cli.tsx
+++ b/src/cli.tsx
@@ -11,7 +11,6 @@ const cli = meow(
 	Options
 		--target <branch>    Target branch to rebase onto (optional, interactive selection if omitted)
 		--allow-empty        Allow empty commits during cherry-pick
-		--skip               Skip empty commits during cherry-pick
 		--linear             Use git rebase for linear history (default: cherry-pick)
 		--continue-on-conflict   Continue rebase even on conflicts (forces conflict resolution)
 		--remote-target      Use remote branches for target selection
@@ -22,7 +21,6 @@ const cli = meow(
 	  $ agrb --linear --continue-on-conflict
 	  $ agrb --remote-target
 	  $ agrb --allow-empty
-	  $ agrb --skip
 `,
 	{
 		importMeta: import.meta,
@@ -32,9 +30,6 @@ const cli = meow(
 				shortFlag: "t",
 			},
 			allowEmpty: {
-				type: "boolean",
-			},
-			skip: {
 				type: "boolean",
 			},
 			linear: {
@@ -54,7 +49,6 @@ render(
 	<App
 		targetBranch={cli.flags.target}
 		allowEmpty={cli.flags.allowEmpty}
-		skip={cli.flags.skip}
 		linear={cli.flags.linear}
 		continueOnConflict={cli.flags.continueOnConflict}
 		remoteTarget={cli.flags.remoteTarget}

--- a/src/git.ts
+++ b/src/git.ts
@@ -109,7 +109,6 @@ export class GitOperations {
 		progressCallback?: (message: string) => void,
 		options?: {
 			allowEmpty?: boolean;
-			skip?: boolean;
 			linear?: boolean;
 			continueOnConflict?: boolean;
 		},
@@ -159,9 +158,8 @@ export class GitOperations {
 					const errorMessage =
 						error instanceof Error ? error.message : String(error);
 					if (
-						options?.skip &&
-						(errorMessage.includes("empty") ||
-							errorMessage.includes("CONFLICT"))
+						errorMessage.includes("empty") ||
+						errorMessage.includes("CONFLICT")
 					) {
 						try {
 							await this.git.raw(["cherry-pick", "--skip"]);


### PR DESCRIPTION
Removes the `--skip` CLI option, simplifying the cherry-pick based rebase strategy.

Empty and conflicting commits are now automatically skipped during cherry-pick by default, enhancing the rebase flow without requiring explicit user intervention. The `--allow-empty` option remains available for users who intend to include empty commits.

Updates `README.md` and `README.ja.md` to reflect these changes and provide a link to the Japanese README.

Introduces `AGENTS.md`, a new comprehensive document detailing the project's overview, build/run instructions, and development conventions.
