### PR TITLE
ci: Enhance npm publish workflow

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -3,6 +3,7 @@ name: Publish to npm
 on:
   release:
     types: [published]
+  workflow_dispatch:
 
 jobs:
   publish:
@@ -26,7 +27,7 @@ jobs:
       - name: Setup Node.js for npm publish
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 #v5.0.0
         with:
-          node-version: 20
+          node-version: 24
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies with frozen lockfile
@@ -34,6 +35,9 @@ jobs:
 
       - name: Build project
         run: bun run build
+
+      - name: Update npm to the latest version
+        run: npm install -g npm@latest
 
       - name: Publish to npm
         run: npm publish --provenance


### PR DESCRIPTION
Adds `workflow_dispatch` to enable manual triggering of the publish job. Upgrades the Node.js version to 24 to align with the latest LTS. Ensures npm is updated to its latest version before publishing for improved reliability.