### PR TITLE
fix(cli): improve error handling for user experience

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -345,6 +345,10 @@ export default function App({
 	]);
 
 	const handleBranchSelect = (item: { label: string; value: string }) => {
+		if (!item) {
+			handleError(new Error("No valid branch selected. Please try again."));
+			return;
+		}
 		if (state.currentBranch) {
 			if (linear) {
 				performLinearRebase(state.currentBranch, item.value);

--- a/src/cli.tsx
+++ b/src/cli.tsx
@@ -61,31 +61,40 @@ const schema = {
 	},
 } as const;
 
-const parser = new ArgParser({
-	schema,
-	helpMessage,
-	version: packageJson.version,
-});
+try {
+	const parser = new ArgParser({
+		schema,
+		helpMessage,
+		version: packageJson.version,
+	});
 
-const cli = parser.parse(process.argv.slice(2));
+	const cli = parser.parse(process.argv.slice(2));
 
-if (cli.help) {
-	console.log(cli.help);
-	process.exit(0);
+	if (cli.help) {
+		console.log(cli.help);
+		process.exit(0);
+	}
+
+	if (cli.version) {
+		console.log(cli.version);
+		process.exit(0);
+	}
+
+	render(
+		<App
+			targetBranch={cli.flags.target}
+			allowEmpty={cli.flags.allowEmpty}
+			linear={cli.flags.linear}
+			continueOnConflict={cli.flags.continueOnConflict}
+			remoteTarget={cli.flags.remoteTarget}
+			onConflict={cli.flags.onConflict}
+		/>,
+	);
+} catch (error) {
+	if (error instanceof Error) {
+		console.error(`❌ ${error.message}`);
+		process.exit(1);
+	}
+	console.error(error);
+	process.exit(1);
 }
-
-if (cli.version) {
-	console.log(cli.version);
-	process.exit(0);
-}
-
-render(
-	<App
-		targetBranch={cli.flags.target}
-		allowEmpty={cli.flags.allowEmpty}
-		linear={cli.flags.linear}
-		continueOnConflict={cli.flags.continueOnConflict}
-		remoteTarget={cli.flags.remoteTarget}
-		onConflict={cli.flags.onConflict}
-	/>,
-);

--- a/src/cli.tsx
+++ b/src/cli.tsx
@@ -93,8 +93,8 @@ try {
 } catch (error) {
 	if (error instanceof Error) {
 		console.error(`❌ ${error.message}`);
-		process.exit(1);
+	} else {
+		console.error(error);
 	}
-	console.error(error);
 	process.exit(1);
 }


### PR DESCRIPTION
fix: #35 

## Summary

This pull request enhances the CLI's error handling to provide a more robust and user-friendly experience. It specifically addresses two issues: an unhandled TypeError during interactive branch selection and the display of full stack traces for argument parsing errors.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- **`src/app.tsx`**: Added a validation check in `handleBranchSelect` to handle cases where no branch is selected. This prevents a `TypeError` and instead displays a clear error message to the user.
- **`src/cli.tsx`**: Wrapped the main application logic in a `try-catch` block. This catches exceptions from the argument parser, allowing the CLI to display a clean, user-friendly error message instead of a full stack trace.

## Testing

I manually verified the fixes for both reported scenarios:

- [x] I have tested this manually
- [ ] I have added/updated tests where appropriate
- [x] All existing tests pass

**Manual Test Cases:**

1.  **Invalid branch selection:**
    - Ran `agrb` to enter interactive mode.
    - Typed random text that did not match any branch.
    - Pressed Enter.
    - **Result:** The CLI now correctly displays the error message "❌ No valid branch selected. Please try again." instead of crashing.

2.  **Argument parsing error:**
    - Ran `agrb -t` without providing a branch name.
    - **Result:** The CLI now shows the clean error "❌ Flag --target requires a value." and exits, instead of printing a stack trace.

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published