### PR TITLE
fix(lib): Correctly parse kebab-case arguments

### DIFF
--- a/src/git.ts
+++ b/src/git.ts
@@ -127,14 +127,11 @@ export class GitOperations {
 
 	async cherryPick(
 		commitSha: string,
-		options?: { allowEmpty?: boolean; strategy?: "ours" | "theirs" },
+		options?: { allowEmpty?: boolean },
 	): Promise<void> {
 		const args = ["cherry-pick"];
 		if (options?.allowEmpty) {
 			args.push("--allow-empty");
-		}
-		if (options?.strategy) {
-			args.push("-X", options.strategy);
 		}
 		args.push(commitSha);
 		await this.git.raw(args);
@@ -152,6 +149,13 @@ export class GitOperations {
 		try {
 			await this.git.raw(["cherry-pick", "--abort"]);
 		} catch {}
+	}
+
+	async resolveConflictWithStrategy(
+		strategy: "ours" | "theirs",
+	): Promise<void> {
+		await this.git.checkout([`--${strategy}`, "."]);
+		await this.git.add(".");
 	}
 
 	async finishCherryPick(

--- a/src/lib/arg-parser.ts
+++ b/src/lib/arg-parser.ts
@@ -32,12 +32,16 @@ export class ArgParser<T extends FlagsSchema> {
 		this.helpMessage = config.helpMessage;
 		this.version = config.version;
 
+		const camelToKebab = (str: string) =>
+			str.replace(/[A-Z]/g, (letter) => `-${letter.toLowerCase()}`);
+
 		for (const longFlag in this.schema) {
 			if (Object.hasOwn(this.schema, longFlag)) {
 				const flagConfig = this.schema[longFlag];
-				this.longFlagMap[`--${longFlag}`] = longFlag;
+				const kebabCaseFlag = camelToKebab(longFlag);
+				this.longFlagMap[`--${kebabCaseFlag}`] = longFlag;
 				if (flagConfig?.shortFlag) {
-					this.aliases[`-${flagConfig.shortFlag}`] = `--${longFlag}`;
+					this.aliases[`-${flagConfig.shortFlag}`] = `--${kebabCaseFlag}`;
 				}
 			}
 		}


### PR DESCRIPTION
# Summary

This PR fixes a bug where the `--on-conflict` argument was being ignored by the parser. This ensures that conflict resolution strategies such as `skip`, `ours`, and `theirs` work as intended.

# Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

# Changes Made

- **`arg-parser.ts`**: Fixed the argument parser to correctly convert kebab-case command-line arguments (e.g., `--on-conflict`) to their camelCase representation used internally (e.g., `onConflict`).
- **`app.tsx` & `git.ts`**: Refactored the conflict handling logic to be more robust and consistent. This ensures all strategies are handled uniformly after a conflict is detected, and fixes a logic bug where `ours`/`theirs` would abort the rebase on failure instead of allowing for resolution.

# Testing

- [x] I have tested this manually
  - Verified that `bun run ./dist/cli.js --on-conflict skip` correctly skips conflicting commits.
  - Verified that `bun run ./dist/cli.js --on-conflict ours` correctly resolves conflicts using the 'ours' strategy and continues the rebase.
- [x] All existing tests pass

# Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
