### PR TITLE
feat(branch-selector): Add label prefix for branches

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -425,6 +425,7 @@ export default function App({
 					<BranchSelector
 						branches={state.availableBranches}
 						onSelect={handleBranchSelect}
+						labelPrefix={remoteTarget ? "origin/" : undefined}
 					/>
 				)}
 				{state.status === "paused_on_conflict" && (

--- a/src/components/BranchSelector.tsx
+++ b/src/components/BranchSelector.tsx
@@ -5,9 +5,10 @@ import { useState } from "react";
 type Props = {
 	branches: string[];
 	onSelect: (branch: string) => void;
+	labelPrefix?: string;
 };
 
-export const BranchSelector = ({ branches, onSelect }: Props) => {
+export const BranchSelector = ({ branches, onSelect, labelPrefix }: Props) => {
 	const [searchTerm, setSearchTerm] = useState("");
 
 	useInput(
@@ -30,7 +31,8 @@ export const BranchSelector = ({ branches, onSelect }: Props) => {
 
 	const filteredBranches =
 		branches.filter((branch) => {
-			const branchLower = branch.toLowerCase();
+			const displayLabel = `${labelPrefix ?? ""}${branch}`;
+			const labelLower = displayLabel.toLowerCase();
 			const searchTerms = searchTerm
 				.toLowerCase()
 				.split(/\s+/)
@@ -38,7 +40,7 @@ export const BranchSelector = ({ branches, onSelect }: Props) => {
 			if (searchTerms.length === 0) {
 				return true;
 			}
-			return searchTerms.every((term) => branchLower.includes(term));
+			return searchTerms.every((term) => labelLower.includes(term));
 		}) || [];
 
 	const handleSelect = (item: { label: string; value: string } | undefined) => {
@@ -53,7 +55,7 @@ export const BranchSelector = ({ branches, onSelect }: Props) => {
 			{searchTerm && <Text color="gray">Filter: {searchTerm}</Text>}
 			<SelectInput
 				items={filteredBranches.map((branch) => ({
-					label: branch,
+					label: `${labelPrefix ?? ""}${branch}`,
 					value: branch,
 				}))}
 				onSelect={handleSelect}

--- a/src/components/BranchSelector.tsx
+++ b/src/components/BranchSelector.tsx
@@ -29,10 +29,14 @@ export const BranchSelector = ({ branches, onSelect, labelPrefix }: Props) => {
 		{ isActive: true },
 	);
 
-	const filteredBranches =
-		branches.filter((branch) => {
-			const displayLabel = `${labelPrefix ?? ""}${branch}`;
-			const labelLower = displayLabel.toLowerCase();
+	const items = branches.map((branch) => ({
+		label: `${labelPrefix ?? ""}${branch}`,
+		value: branch,
+	}));
+
+	const filteredItems =
+		items.filter(({ label }) => {
+			const labelLower = label.toLowerCase();
 			const searchTerms = searchTerm
 				.toLowerCase()
 				.split(/\s+/)
@@ -53,13 +57,7 @@ export const BranchSelector = ({ branches, onSelect, labelPrefix }: Props) => {
 		<Box flexDirection="column">
 			<Text>Select target branch (type to filter):</Text>
 			{searchTerm && <Text color="gray">Filter: {searchTerm}</Text>}
-			<SelectInput
-				items={filteredBranches.map((branch) => ({
-					label: `${labelPrefix ?? ""}${branch}`,
-					value: branch,
-				}))}
-				onSelect={handleSelect}
-			/>
+			<SelectInput items={filteredItems} onSelect={handleSelect} />
 		</Box>
 	);
 };


### PR DESCRIPTION
## Summary

Introduces a `labelPrefix` prop to the `BranchSelector` component. This allows displaying branches with a custom prefix, enhancing clarity by distinguishing between local and remote branches (e.g., `origin/main`). 

## Type of Change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Testing

```
 Auto Rebase

 riya-amemiya/remote-target-fix → 

 Select target branch (type to filter):
 ❯ origin/feature/1.0.0
   origin/main
   origin/riya-amemiya/add
```

- [x] I have tested this manually
- [x] I have added/updated tests where appropriate
- [x] All existing tests pass