### PR TITLE
feat: add default values from config for CLI flags

### DIFF
--- a/src/cli.tsx
+++ b/src/cli.tsx
@@ -186,11 +186,11 @@ try {
 				cli.flags.continueOnConflict ?? config.continueOnConflict,
 			remoteTarget: cli.flags.remoteTarget ?? config.remoteTarget,
 			onConflict: cli.flags.onConflict ?? config.onConflict,
-			dryRun: cli.flags.dryRun ?? false,
-			yes: cli.flags.yes ?? false,
-			autostash: cli.flags.autostash ?? false,
-			pushWithLease: cli.flags.pushWithLease ?? false,
-			noBackup: cli.flags.noBackup ?? false,
+			dryRun: cli.flags.dryRun ?? config.dryRun,
+			yes: cli.flags.yes ?? config.yes,
+			autostash: cli.flags.autostash ?? config.autostash,
+			pushWithLease: cli.flags.pushWithLease ?? config.pushWithLease,
+			noBackup: cli.flags.noBackup ?? config.noBackup,
 		};
 
 		render(

--- a/src/cli.tsx
+++ b/src/cli.tsx
@@ -178,36 +178,29 @@ try {
 			? { config: defaultConfig }
 			: await getConfig();
 
+		const configurableFlags = [
+			"allowEmpty",
+			"linear",
+			"continueOnConflict",
+			"remoteTarget",
+			"onConflict",
+			"dryRun",
+			"yes",
+			"autostash",
+			"pushWithLease",
+			"noBackup",
+		] as const;
+
+		const flagProps = Object.fromEntries(
+			configurableFlags.map((flag) => [flag, cli.flags[flag] ?? config[flag]]),
+		);
+
 		const props = {
 			targetBranch: cli.flags.target,
-			allowEmpty: cli.flags.allowEmpty ?? config.allowEmpty,
-			linear: cli.flags.linear ?? config.linear,
-			continueOnConflict:
-				cli.flags.continueOnConflict ?? config.continueOnConflict,
-			remoteTarget: cli.flags.remoteTarget ?? config.remoteTarget,
-			onConflict: cli.flags.onConflict ?? config.onConflict,
-			dryRun: cli.flags.dryRun ?? config.dryRun,
-			yes: cli.flags.yes ?? config.yes,
-			autostash: cli.flags.autostash ?? config.autostash,
-			pushWithLease: cli.flags.pushWithLease ?? config.pushWithLease,
-			noBackup: cli.flags.noBackup ?? config.noBackup,
+			...flagProps,
 		};
 
-		render(
-			<App
-				targetBranch={props.targetBranch}
-				allowEmpty={props.allowEmpty}
-				linear={props.linear}
-				continueOnConflict={props.continueOnConflict}
-				remoteTarget={props.remoteTarget}
-				onConflict={props.onConflict}
-				dryRun={props.dryRun}
-				yes={props.yes}
-				autostash={props.autostash}
-				pushWithLease={props.pushWithLease}
-				noBackup={props.noBackup}
-			/>,
-		);
+		render(<App {...props} />);
 	})();
 } catch (error) {
 	if (error instanceof Error) {

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -23,6 +23,11 @@ const configSchema = object({
 	continueOnConflict: optional(boolean()),
 	remoteTarget: optional(boolean()),
 	onConflict: optional(picklist(onConflictValues)),
+	dryRun: optional(boolean()),
+	yes: optional(boolean()),
+	autostash: optional(boolean()),
+	pushWithLease: optional(boolean()),
+	noBackup: optional(boolean()),
 	schemaVersion: optional(number()),
 });
 
@@ -32,6 +37,11 @@ export const configKeys = [
 	"continueOnConflict",
 	"remoteTarget",
 	"onConflict",
+	"dryRun",
+	"yes",
+	"autostash",
+	"pushWithLease",
+	"noBackup",
 	"schemaVersion",
 ] as const;
 
@@ -41,6 +51,11 @@ export interface AgreConfig {
 	continueOnConflict?: boolean;
 	remoteTarget?: boolean;
 	onConflict?: OnConflictStrategy;
+	dryRun?: boolean;
+	yes?: boolean;
+	autostash?: boolean;
+	pushWithLease?: boolean;
+	noBackup?: boolean;
 	schemaVersion?: number;
 }
 
@@ -55,6 +70,11 @@ export const defaultConfig: Omit<AgreConfig, "schemaVersion"> = {
 	continueOnConflict: false,
 	remoteTarget: false,
 	onConflict: "pause",
+	dryRun: false,
+	yes: false,
+	autostash: false,
+	pushWithLease: false,
+	noBackup: false,
 };
 
 const validateConfig = (config: unknown): AgreConfig => {

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -3,6 +3,7 @@ import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import {
 	boolean,
+	type InferOutput,
 	number,
 	object,
 	optional,
@@ -15,7 +16,6 @@ const CONFIG_DIR_NAME = "agrb";
 const LOCAL_CONFIG_FILE_NAME = ".agrbrc";
 
 const onConflictValues = ["skip", "ours", "theirs", "pause"] as const;
-type OnConflictStrategy = (typeof onConflictValues)[number];
 
 const configSchema = object({
 	allowEmpty: optional(boolean()),
@@ -31,6 +31,8 @@ const configSchema = object({
 	schemaVersion: optional(number()),
 });
 
+export type AgreConfig = InferOutput<typeof configSchema>;
+
 export const configKeys = [
 	"allowEmpty",
 	"linear",
@@ -44,20 +46,6 @@ export const configKeys = [
 	"noBackup",
 	"schemaVersion",
 ] as const;
-
-export interface AgreConfig {
-	allowEmpty?: boolean;
-	linear?: boolean;
-	continueOnConflict?: boolean;
-	remoteTarget?: boolean;
-	onConflict?: OnConflictStrategy;
-	dryRun?: boolean;
-	yes?: boolean;
-	autostash?: boolean;
-	pushWithLease?: boolean;
-	noBackup?: boolean;
-	schemaVersion?: number;
-}
 
 export interface ConfigResult {
 	config: AgreConfig;
@@ -97,7 +85,7 @@ const validateConfig = (config: unknown): AgreConfig => {
 		});
 		throw new Error(`Configuration errors:\n- ${errors.join("\n- ")}`);
 	}
-	return result.output as AgreConfig;
+	return result.output;
 };
 
 const readConfigFile = async (filePath: string): Promise<AgreConfig | null> => {


### PR DESCRIPTION
## Summary

Add support for reading default values from config file for CLI boolean flags (dryRun, yes, autostash, pushWithLease, noBackup).

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Changes Made

- Added new optional boolean fields to config schema: dryRun, yes, autostash, pushWithLease, noBackup
- Updated CLI flag handling to use config defaults when flags are not explicitly provided
- Extended default config object with new boolean fields (all defaulting to false)

## Testing

Describe the tests that you ran to verify your changes. Provide instructions so others can reproduce.

- [x] I have tested this manually
- [ ] I have added/updated tests where appropriate
- [ ] All existing tests pass

## Screenshots (if applicable)

N/A

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Context

This change allows users to set their preferred defaults for boolean flags in the configuration file, reducing the need to specify them on every command invocation. This maintains backward compatibility as all new config fields are optional and default to false.