### PR TITLE
feat: add default values from config for CLI flags

### DIFF
--- a/.github/workflows/cherry-pick-release-to-main.yml
+++ b/.github/workflows/cherry-pick-release-to-main.yml
@@ -1,0 +1,104 @@
+name: Sync release commits forward
+
+'on':
+  push:
+    branches:
+      - 'release/*.*.x'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: sync-commits-${{ github.ref_name }}
+  cancel-in-progress: false
+
+jobs:
+  cherry-pick:
+    name: Sync commits to branches
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    if: ${{ startsWith(github.event.head_commit.message, '[sync]') == false && contains(github.event.head_commit.message, 'npm version') == false && contains(github.event.head_commit.message, 'version bump') == false && !startsWith(github.event.head_commit.message, '1.') && !startsWith(github.event.head_commit.message, '2.') && !startsWith(github.event.head_commit.message, '3.') && !startsWith(github.event.head_commit.message, '4.') && !startsWith(github.event.head_commit.message, '5.') && !startsWith(github.event.head_commit.message, '6.') && !startsWith(github.event.head_commit.message, '7.') && !startsWith(github.event.head_commit.message, '8.') && !startsWith(github.event.head_commit.message, '9.') && !startsWith(github.event.head_commit.message, '0.') }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Create per-commit PRs to main and forward release branches
+        env:
+          RELEASE_BRANCH: ${{ github.ref_name }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git fetch origin --prune --tags
+          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+
+          # Ensure target branches exist
+          if ! git show-ref --verify --quiet "refs/remotes/origin/${RELEASE_BRANCH}"; then
+            echo "Release branch not found: ${RELEASE_BRANCH}"
+            exit 1
+          fi
+          git fetch origin main:refs/remotes/origin/main
+
+          # Build target list: main + forward release branches (greater than source version)
+          TARGETS=(main)
+          if [[ "${RELEASE_BRANCH}" =~ ^release/([0-9]+)\.([0-9]+)\.x$ ]]; then
+            SRC_MAJ="${BASH_REMATCH[1]}"
+            SRC_MIN="${BASH_REMATCH[2]}"
+            mapfile -t ALL_RELEASES < <(git ls-remote --heads origin 'refs/heads/release/*.*.x' | awk '{print $2}' | sed 's#refs/heads/##')
+            for rb in "${ALL_RELEASES[@]}"; do
+              [[ "$rb" == "${RELEASE_BRANCH}" ]] && continue
+              if [[ "$rb" =~ ^release/([0-9]+)\.([0-9]+)\.x$ ]]; then
+                maj="${BASH_REMATCH[1]}"; min="${BASH_REMATCH[2]}"
+                if (( maj > SRC_MAJ )) || { (( maj == SRC_MAJ )) && (( min > SRC_MIN )); }; then
+                  TARGETS+=("$rb")
+                fi
+              fi
+            done
+          else
+            echo "::warning::Release branch '${RELEASE_BRANCH}' doesn't match release/<major>.<minor>.x; syncing only to main."
+          fi
+
+          echo "Targets: ${TARGETS[*]}"
+
+          for target in "${TARGETS[@]}"; do
+            echo "Finding commits to apply to ${target} from ${RELEASE_BRANCH}"
+            git fetch origin "${target}:refs/remotes/origin/${target}" || true
+            # Commits present in source but not in target (compare by patch-id), oldest first
+            mapfile -t COMMITS < <(git rev-list --reverse --cherry-pick --right-only --no-merges "origin/${target}...origin/${RELEASE_BRANCH}")
+            echo "Commits to cherry-pick for ${target}: ${#COMMITS[@]}"
+            if [ "${#COMMITS[@]}" -eq 0 ]; then
+              continue
+            fi
+
+            for c in "${COMMITS[@]}"; do
+              shortsha="$(git rev-parse --short "$c")"
+              sanitized_target="$(echo "${target}" | sed -E 's#[^A-Za-z0-9._-]+#-#g')"
+              wbranch="sync/${shortsha}-to-${sanitized_target}"
+              echo "Processing $c on branch ${wbranch} -> base ${target}"
+
+              # Fresh branch from target for each commit
+              git checkout -B "${wbranch}" "origin/${target}"
+              if ! git cherry-pick -x "$c"; then
+                echo "::warning::Cherry-pick had conflicts on $c. Committing with conflict markers."
+                git add -A
+                if ! git cherry-pick --continue; then
+                  git commit -m "chore: sync ${c} to ${target} (with conflicts)"
+                fi
+              fi
+
+              git push --force-with-lease origin "${wbranch}"
+
+              title="sync ${shortsha} to ${target}"
+              commit_url="${GITHUB_SERVER_URL:-https://github.com}/${GITHUB_REPOSITORY}/commit/${c}"
+              body="Auto PR to sync commit ${c} from '${RELEASE_BRANCH}' into '${target}'.\n\nCommit: ${commit_url}\n\nConflicts, if any, are intentionally kept for PR-side resolution."
+              gh pr create --base "${target}" --head "${wbranch}" --title "${title}" --body "${body}" || echo "PR may already exist for ${wbranch}; skipping"
+            done
+          done
+
+

--- a/src/cli.tsx
+++ b/src/cli.tsx
@@ -186,11 +186,11 @@ try {
 				cli.flags.continueOnConflict ?? config.continueOnConflict,
 			remoteTarget: cli.flags.remoteTarget ?? config.remoteTarget,
 			onConflict: cli.flags.onConflict ?? config.onConflict,
-			dryRun: cli.flags.dryRun ?? false,
-			yes: cli.flags.yes ?? false,
-			autostash: cli.flags.autostash ?? false,
-			pushWithLease: cli.flags.pushWithLease ?? false,
-			noBackup: cli.flags.noBackup ?? false,
+			dryRun: cli.flags.dryRun ?? config.dryRun,
+			yes: cli.flags.yes ?? config.yes,
+			autostash: cli.flags.autostash ?? config.autostash,
+			pushWithLease: cli.flags.pushWithLease ?? config.pushWithLease,
+			noBackup: cli.flags.noBackup ?? config.noBackup,
 		};
 
 		render(

--- a/src/cli.tsx
+++ b/src/cli.tsx
@@ -178,36 +178,29 @@ try {
 			? { config: defaultConfig }
 			: await getConfig();
 
+		const configurableFlags = [
+			"allowEmpty",
+			"linear",
+			"continueOnConflict",
+			"remoteTarget",
+			"onConflict",
+			"dryRun",
+			"yes",
+			"autostash",
+			"pushWithLease",
+			"noBackup",
+		] as const;
+
+		const flagProps = Object.fromEntries(
+			configurableFlags.map((flag) => [flag, cli.flags[flag] ?? config[flag]]),
+		);
+
 		const props = {
 			targetBranch: cli.flags.target,
-			allowEmpty: cli.flags.allowEmpty ?? config.allowEmpty,
-			linear: cli.flags.linear ?? config.linear,
-			continueOnConflict:
-				cli.flags.continueOnConflict ?? config.continueOnConflict,
-			remoteTarget: cli.flags.remoteTarget ?? config.remoteTarget,
-			onConflict: cli.flags.onConflict ?? config.onConflict,
-			dryRun: cli.flags.dryRun ?? config.dryRun,
-			yes: cli.flags.yes ?? config.yes,
-			autostash: cli.flags.autostash ?? config.autostash,
-			pushWithLease: cli.flags.pushWithLease ?? config.pushWithLease,
-			noBackup: cli.flags.noBackup ?? config.noBackup,
+			...flagProps,
 		};
 
-		render(
-			<App
-				targetBranch={props.targetBranch}
-				allowEmpty={props.allowEmpty}
-				linear={props.linear}
-				continueOnConflict={props.continueOnConflict}
-				remoteTarget={props.remoteTarget}
-				onConflict={props.onConflict}
-				dryRun={props.dryRun}
-				yes={props.yes}
-				autostash={props.autostash}
-				pushWithLease={props.pushWithLease}
-				noBackup={props.noBackup}
-			/>,
-		);
+		render(<App {...props} />);
 	})();
 } catch (error) {
 	if (error instanceof Error) {

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -23,6 +23,11 @@ const configSchema = object({
 	continueOnConflict: optional(boolean()),
 	remoteTarget: optional(boolean()),
 	onConflict: optional(picklist(onConflictValues)),
+	dryRun: optional(boolean()),
+	yes: optional(boolean()),
+	autostash: optional(boolean()),
+	pushWithLease: optional(boolean()),
+	noBackup: optional(boolean()),
 	schemaVersion: optional(number()),
 });
 
@@ -32,6 +37,11 @@ export const configKeys = [
 	"continueOnConflict",
 	"remoteTarget",
 	"onConflict",
+	"dryRun",
+	"yes",
+	"autostash",
+	"pushWithLease",
+	"noBackup",
 	"schemaVersion",
 ] as const;
 
@@ -41,6 +51,11 @@ export interface AgreConfig {
 	continueOnConflict?: boolean;
 	remoteTarget?: boolean;
 	onConflict?: OnConflictStrategy;
+	dryRun?: boolean;
+	yes?: boolean;
+	autostash?: boolean;
+	pushWithLease?: boolean;
+	noBackup?: boolean;
 	schemaVersion?: number;
 }
 
@@ -55,6 +70,11 @@ export const defaultConfig: Omit<AgreConfig, "schemaVersion"> = {
 	continueOnConflict: false,
 	remoteTarget: false,
 	onConflict: "pause",
+	dryRun: false,
+	yes: false,
+	autostash: false,
+	pushWithLease: false,
+	noBackup: false,
 };
 
 const validateConfig = (config: unknown): AgreConfig => {

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -3,6 +3,7 @@ import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import {
 	boolean,
+	type InferOutput,
 	number,
 	object,
 	optional,
@@ -15,7 +16,6 @@ const CONFIG_DIR_NAME = "agrb";
 const LOCAL_CONFIG_FILE_NAME = ".agrbrc";
 
 const onConflictValues = ["skip", "ours", "theirs", "pause"] as const;
-type OnConflictStrategy = (typeof onConflictValues)[number];
 
 const configSchema = object({
 	allowEmpty: optional(boolean()),
@@ -31,6 +31,8 @@ const configSchema = object({
 	schemaVersion: optional(number()),
 });
 
+export type AgreConfig = InferOutput<typeof configSchema>;
+
 export const configKeys = [
 	"allowEmpty",
 	"linear",
@@ -44,20 +46,6 @@ export const configKeys = [
 	"noBackup",
 	"schemaVersion",
 ] as const;
-
-export interface AgreConfig {
-	allowEmpty?: boolean;
-	linear?: boolean;
-	continueOnConflict?: boolean;
-	remoteTarget?: boolean;
-	onConflict?: OnConflictStrategy;
-	dryRun?: boolean;
-	yes?: boolean;
-	autostash?: boolean;
-	pushWithLease?: boolean;
-	noBackup?: boolean;
-	schemaVersion?: number;
-}
 
 export interface ConfigResult {
 	config: AgreConfig;
@@ -97,7 +85,7 @@ const validateConfig = (config: unknown): AgreConfig => {
 		});
 		throw new Error(`Configuration errors:\n- ${errors.join("\n- ")}`);
 	}
-	return result.output as AgreConfig;
+	return result.output;
 };
 
 const readConfigFile = async (filePath: string): Promise<AgreConfig | null> => {


### PR DESCRIPTION
## Summary

Add support for reading default values from config file for CLI boolean flags (dryRun, yes, autostash, pushWithLease, noBackup).

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Changes Made

- Added new optional boolean fields to config schema: dryRun, yes, autostash, pushWithLease, noBackup
- Updated CLI flag handling to use config defaults when flags are not explicitly provided
- Extended default config object with new boolean fields (all defaulting to false)

## Testing

Describe the tests that you ran to verify your changes. Provide instructions so others can reproduce.

- [x] I have tested this manually
- [ ] I have added/updated tests where appropriate
- [ ] All existing tests pass

## Screenshots (if applicable)

N/A

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Context

This change allows users to set their preferred defaults for boolean flags in the configuration file, reducing the need to specify them on every command invocation. This maintains backward compatibility as all new config fields are optional and default to false.