### PR TITLE
feat(rebase): Prompt for cherry-pick rebase upfront

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "agrb",
-	"version": "1.0.1",
+	"version": "1.0.2",
 	"description": "Interactive CLI to rebase a branch onto another safely (cherry-pick or linear rebase)",
 	"license": "MIT",
 	"bin": "dist/cli.js",

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -169,6 +169,26 @@ export default function App({
 	const startCherryPickRebase = useCallback(
 		async (currentBranch: string, target: string) => {
 			try {
+				if (!yes && stateRef.current.status !== "confirm") {
+					setState((prev) => ({
+						...prev,
+						status: "confirm",
+						message: `Proceed to rebase ${currentBranch} onto ${target} (cherry-pick)? Press Enter to continue, Esc to cancel.`,
+						currentBranch,
+						targetBranch: target,
+						pendingMode: "cherry",
+					}));
+					return;
+				}
+
+				setState((prev) => ({
+					...prev,
+					status: "loading",
+					message: "Analyzing commits...",
+					currentBranch,
+					targetBranch: target,
+				}));
+
 				await gitOps.fetchAll();
 				if (!(await gitOps.branchExists(target))) {
 					throw new Error(`Target branch '${target}' does not exist`);
@@ -186,20 +206,6 @@ export default function App({
 						message: `DRY-RUN: Would apply ${commits.length} commits from ${mergeBase.slice(0, 7)}..${currentBranch} onto ${target} (cherry-pick).`,
 						currentBranch,
 						targetBranch: target,
-					}));
-					return;
-				}
-
-				if (!yes && stateRef.current.status !== "confirm") {
-					setState((prev) => ({
-						...prev,
-						status: "confirm",
-						message: `Proceed to apply ${commits.length} commits onto ${target}? Press Enter to continue, Esc to cancel.`,
-						currentBranch,
-						targetBranch: target,
-						pendingMode: "cherry",
-						commitsToPick: commits,
-						currentCommitIndex: 0,
 					}));
 					return;
 				}


### PR DESCRIPTION
## Summary

Moves the cherry-pick rebase confirmation prompt to occur before any commit analysis.

This improves the user experience by allowing immediate confirmation or cancellation of the operation, preventing unnecessary waiting for commit analysis to complete. It also provides immediate feedback with a "Analyzing commits..." loading state once confirmed.

## Type of Change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
