### PR TITLE
ci: Prevents empty commits during cherry-pick conflicts

### DIFF
--- a/.github/workflows/cherry-pick-release-to-main.yml
+++ b/.github/workflows/cherry-pick-release-to-main.yml
@@ -87,6 +87,12 @@ jobs:
               if ! git cherry-pick -x "$c"; then
                 echo "::warning::Cherry-pick had conflicts on $c. Committing with conflict markers."
                 git add -A
+                if git diff --cached --quiet; then
+                  echo "Empty commit after conflict resolution. Skipping."
+                  git cherry-pick --abort
+                  continue
+                fi
+
                 if ! git cherry-pick --continue; then
                   git commit -m "chore: sync ${c} to ${target} (with conflicts)"
                 fi


### PR DESCRIPTION
Adds a check to avoid creating empty commits when resolving cherry-pick conflicts. If a conflict resolution results in no actual changes being staged, the current cherry-pick is aborted to prevent an unnecessary empty commit.
