### PR TITLE
feat: support remote-target with target option to rebase onto origin/branch

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -448,10 +448,15 @@ export default function App({
 						message: "Select target branch (type to filter):",
 						availableBranches: filteredBranches,
 					}));
-				} else if (linear) {
-					await performLinearRebase(currentBranch, initialTargetBranch);
 				} else {
-					await startCherryPickRebase(currentBranch, initialTargetBranch);
+					const targetBranch = remoteTarget
+						? `origin/${initialTargetBranch}`
+						: initialTargetBranch;
+					if (linear) {
+						await performLinearRebase(currentBranch, targetBranch);
+					} else {
+						await startCherryPickRebase(currentBranch, targetBranch);
+					}
 				}
 			} catch (error) {
 				await handleError(error);


### PR DESCRIPTION
## Summary

Added support for combining `--remote-target` flag with `--target` option to enable rebasing directly onto remote branches (`origin/branch`).

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Changes Made

- Modified `src/app.tsx` to prepend `origin/` prefix to target branch when `remoteTarget` flag is enabled
- Added `stripOriginPrefix` method in `src/git.ts` to properly handle `origin/` prefix
- Updated `branchExists`, `setupCherryPick`, `getMergeBase`, and `performLinearRebase` methods to correctly handle branch names with `origin/` prefix
- Modified `resolveBranchRef` method to return branches starting with `origin/` as-is

## Testing

- [x] I have tested this manually
- [ ] I have added/updated tests where appropriate
- [x] All existing tests pass

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Additional Context

This feature allows users to rebase onto remote branches directly, even when the branch doesn't exist locally.