### PR TITLE
ci(workflows): fix PR body newlines in cherry-pick workflow

### DIFF
--- a/.github/workflows/cherry-pick-release-to-main.yml
+++ b/.github/workflows/cherry-pick-release-to-main.yml
@@ -102,8 +102,7 @@ jobs:
 
               title="sync ${shortsha} to ${target}"
               commit_url="${GITHUB_SERVER_URL:-https://github.com}/${GITHUB_REPOSITORY}/commit/${c}"
-              body="Auto PR to sync commit ${c} from '${RELEASE_BRANCH}' into '${target}'.\n\nCommit: ${commit_url}\n\nConflicts, if any, are intentionally kept for PR-side resolution."
-              gh pr create --base "${target}" --head "${wbranch}" --title "${title}" --body "${body}" || echo "PR may already exist for ${wbranch}; skipping"
+              echo -e "Auto PR to sync commit ${c} from '${RELEASE_BRANCH}' into '${target}'.\n\nCommit: ${commit_url}\n\nConflicts, if any, are intentionally kept for PR-side resolution." | gh pr create --base "${target}" --head "${wbranch}" --title "${title}" --body-file - || echo "PR may already exist for ${wbranch}; skipping"
             done
           done
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,15 +4,17 @@
 
 We currently support the following versions of agrb with security updates:
 
-| Version | Supported          |
+| Version | Supported |
 | ------- | ------------------ |
-| 1.0.x   | ✅ Yes              |
-| 0.6.x   | ⚠️ Maintenance only |
-| 0.5.x   | ❌ No              |
-| 0.4.x   | ❌ No              |
-| 0.3.x   | ❌ No              |
-| 0.2.x   | ❌ No              |
-| 0.1.x   | ❌ No              |
+| 1.2.x | ✅ Yes |
+| 1.1.x | ❌ No |
+| 1.0.x | ❌ No |
+| 0.6.x | ❌ No |
+| 0.5.x | ❌ No |
+| 0.4.x | ❌ No |
+| 0.3.x | ❌ No |
+| 0.2.x | ❌ No |
+| 0.1.x | ❌ No |
 
 ## Reporting a Vulnerability
 


### PR DESCRIPTION
## Summary

Fix cherry-pick workflow to properly render line breaks in PR body text. Also update SECURITY.md to reflect currently supported versions.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update

## Changes Made

- Modified cherry-pick workflow to use `echo -e` with `--body-file -` for proper newline rendering
- Updated SECURITY.md to mark 1.2.x as currently supported version

## Testing

- [x] I have tested this manually
- [x] I have performed a self-review of my code

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
