### PR TITLE
fix: add overrides to enforce consistent react/ink versions

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -31,6 +31,12 @@
       },
     },
   },
+  "overrides": {
+    "ink": "6.8.0",
+    "ink-select-input": "6.2.0",
+    "ink-spinner": "5.0.0",
+    "react": "19.2.4",
+  },
   "packages": {
     "@alcalzone/ansi-tokenize": ["@alcalzone/ansi-tokenize@0.2.5", "", { "dependencies": { "ansi-styles": "^6.2.1", "is-fullwidth-code-point": "^5.0.0" } }, "sha512-3NX/MpTdroi0aKz134A6RC2Gb2iXVECN4QaAXnvCIxxIm3C3AVB1mkUe8NaaiyvOpDfsrqWhYtj+Q6a62RrTsw=="],
 

--- a/package.json
+++ b/package.json
@@ -45,6 +45,12 @@
 		"simple-git": "3.35.2",
 		"umt": "2.14.0"
 	},
+	"overrides": {
+		"react": "19.2.4",
+		"ink": "6.8.0",
+		"ink-select-input": "6.2.0",
+		"ink-spinner": "5.0.0"
+	},
 	"devDependencies": {
 		"@biomejs/biome": "2.4.10",
 		"@eslint/js": "^10.0.1",


### PR DESCRIPTION
Ensures ag-toolkit uses the same react, ink, ink-select-input, and ink-spinner versions as this project, preventing duplicate React instances that break hooks and context sharing.

https://claude.ai/code/session_019xqGkVDgYt4em7apk71fBE

# Pull Request Template

## Summary

Brief description of the changes in this PR.

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe):

## Changes Made

-
-
-

## Testing

Describe the tests that you ran to verify your changes. Provide instructions so others can reproduce.

- [ ] I have tested this manually
- [ ] I have added/updated tests where appropriate
- [ ] All existing tests pass

## Screenshots (if applicable)

If your changes include UI changes, please add screenshots here.

## Checklist

- [ ] My code follows the project's code style
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Context

Add any other context about the pull request here.
