### PR TITLE
fix: harden cherry-pick rebase flow and fix --remote-target

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -81,10 +81,20 @@ export default function App({
 					stateReference.current.currentBranch,
 				);
 			}
+			let stashNote = "";
+			const { stashRef } = stateReference.current;
+			if (stashRef) {
+				try {
+					await gitOps.popStash(stashRef);
+				} catch {
+					stashNote = ` (your changes are still stashed as ${stashRef}; run 'git stash pop ${stashRef}')`;
+				}
+			}
 			setState((previous) => ({
 				...previous,
 				status: "error",
-				message: `Error: ${errorMessage}`,
+				stashRef: undefined,
+				message: `Error: ${errorMessage}${stashNote}`,
 			}));
 		},
 		[gitOps],
@@ -169,7 +179,7 @@ export default function App({
 	const startCherryPickRebase = useCallback(
 		async (currentBranch: string, target: string) => {
 			try {
-				if (!yes && stateReference.current.status !== "confirm") {
+				if (!(dryRun || yes) && stateReference.current.status !== "confirm") {
 					setState((previous) => ({
 						...previous,
 						status: "confirm",
@@ -200,10 +210,25 @@ export default function App({
 				);
 
 				if (dryRun) {
+					const preview =
+						commits.length > 0
+							? ` [${commits.map((sha) => sha.slice(0, 7)).join(", ")}]`
+							: "";
 					setState((previous) => ({
 						...previous,
 						status: "success",
-						message: `DRY-RUN: Would apply ${commits.length} commits from ${mergeBase.slice(0, 7)}..${currentBranch} onto ${target} (cherry-pick).`,
+						message: `DRY-RUN: Would apply ${commits.length} commits from ${mergeBase.slice(0, 7)}..${currentBranch} onto ${target} (cherry-pick).${preview}`,
+						currentBranch,
+						targetBranch: target,
+					}));
+					return;
+				}
+
+				if (commits.length === 0) {
+					setState((previous) => ({
+						...previous,
+						status: "success",
+						message: `Already up to date: no commits to replay onto ${target}.`,
 						currentBranch,
 						targetBranch: target,
 					}));
@@ -311,6 +336,7 @@ export default function App({
 			const errorMessage =
 				error instanceof Error ? error.message : String(error);
 			if (errorMessage.includes("empty")) {
+				await gitOps.skipCherryPick();
 				setState((previous) => ({
 					...previous,
 					message: `Commit ${commit.slice(
@@ -452,15 +478,17 @@ export default function App({
 					);
 				}
 				const currentBranch = await gitOps.getCurrentBranch();
+				if (currentBranch === "HEAD") {
+					throw new Error(
+						"Detached HEAD state detected. Please checkout a branch before running agrb.",
+					);
+				}
 				setState((previous) => ({ ...previous, currentBranch }));
 
 				if (initialTargetBranch) {
-					const targetBranch = remoteTarget
-						? `origin/${initialTargetBranch}`
-						: initialTargetBranch;
 					await (linear
-						? performLinearRebase(currentBranch, targetBranch)
-						: startCherryPickRebase(currentBranch, targetBranch));
+						? performLinearRebase(currentBranch, initialTargetBranch)
+						: startCherryPickRebase(currentBranch, initialTargetBranch));
 				} else {
 					const branches = remoteTarget
 						? await gitOps.getAllBranches()
@@ -534,10 +562,23 @@ export default function App({
 
 			if (key.escape) {
 				if (state.tempBranchName && state.currentBranch) {
+					if (
+						state.status === "paused_on_conflict" ||
+						state.status === "loading"
+					) {
+						await gitOps.abortCherryPick();
+					}
 					await gitOps.cleanupCherryPick(
 						state.tempBranchName,
 						state.currentBranch,
 					);
+				}
+				if (state.stashRef) {
+					try {
+						await gitOps.popStash(state.stashRef);
+					} catch (popError) {
+						void popError;
+					}
 				}
 				exit();
 				return;

--- a/src/components/BranchSelector.tsx
+++ b/src/components/BranchSelector.tsx
@@ -1,6 +1,6 @@
 import { Box, Text, useInput } from "ink";
 import SelectInput from "ink-select-input";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 
 type Properties = {
 	branches: string[];
@@ -32,23 +32,28 @@ export const BranchSelector = ({
 		{ isActive: true },
 	);
 
-	const items = branches.map((branch) => ({
-		label: `${labelPrefix ?? ""}${branch}`,
-		value: branch,
-	}));
+	const items = useMemo(
+		() =>
+			branches.map((branch) => ({
+				label: `${labelPrefix ?? ""}${branch}`,
+				value: branch,
+			})),
+		[branches, labelPrefix],
+	);
 
-	const filteredItems =
-		items.filter(({ label }) => {
+	const filteredItems = useMemo(() => {
+		const searchTerms = searchTerm
+			.toLowerCase()
+			.split(/\s+/)
+			.filter((term) => term.length > 0);
+		if (searchTerms.length === 0) {
+			return items;
+		}
+		return items.filter(({ label }) => {
 			const labelLower = label.toLowerCase();
-			const searchTerms = searchTerm
-				.toLowerCase()
-				.split(/\s+/)
-				.filter((term) => term.length > 0);
-			if (searchTerms.length === 0) {
-				return true;
-			}
 			return searchTerms.every((term) => labelLower.includes(term));
-		}) || [];
+		});
+	}, [items, searchTerm]);
 
 	const handleSelect = (item: { label: string; value: string } | undefined) => {
 		if (item) {


### PR DESCRIPTION
## Summary

Correctness and safety fixes to the rebase flow (this tool rewrites history, so most of these prevent the repo from being left in a bad state), plus a small perf win.

### Bug fixes
- **Restore autostashed changes on failure/cancel.** On any error the stash was never popped, silently stranding the user's uncommitted work. It is now popped on failure and on ESC; if the pop itself conflicts, the exact recovery command is surfaced.
- **Abort an in-progress cherry-pick on ESC.** Pressing ESC mid-conflict previously ran cleanup without `cherry-pick --abort`, leaving the repo in a half-finished cherry-pick. Now aborts first.
- **Skip empty commits in git.** An empty cherry-pick only advanced the React index, so the next pick failed with "cherry-pick already in progress". Now calls `cherry-pick --skip` before advancing.
- **No destructive no-op when nothing to replay.** With zero commits to replay it still created a temp branch, a backup tag, and ran a hard reset. Now short-circuits with "Already up to date".
- **`--remote-target` double prefix.** `GitOperations` already resolves a bare name to `origin/<branch>`, so the manual `origin/` prefix produced `origin/origin/<branch>` and always failed. Pass the bare name.
- **Reject detached HEAD** up front instead of operating on the literal ref `HEAD`.

### UX / feature
- `--dry-run` no longer stops at the confirmation prompt and now lists the short SHAs that would be replayed.

### Performance
- `BranchSelector` memoizes its item list and filtered results (previously rebuilt on every keystroke).

## Testing
- `tsc --noEmit && vite build` → clean.
- `biome ci .` → clean.
- `eslint src` → clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XYUNqCQHzKFShzaejSx7D1

---
_Generated by [Claude Code](https://claude.ai/code/session_01XYUNqCQHzKFShzaejSx7D1)_